### PR TITLE
Remove use of Orange.canvas.resources module

### DIFF
--- a/orangecontrib/wonder/controller/fit/wppm_functions.py
+++ b/orangecontrib/wonder/controller/fit/wppm_functions.py
@@ -455,7 +455,6 @@ def create_one_peak(reflection_index, fit_global_parameters, diffraction_pattern
 import numpy
 from scipy.special import erfc
 import os
-from Orange.canvas import resources
 
 ######################################################################
 # THERMAL AND POLARIZATION
@@ -590,7 +589,7 @@ def load_warren_files():
     delta_l_dict = {}
     delta_l2_dict = {}
 
-    path = os.path.join(resources.package_dirname("orangecontrib.wonder.controller.fit"), "data")
+    path = os.path.join(os.path.dirname(__file__), "data")
     path = os.path.join(path, "delta_l_files")
 
     filenames = os.listdir(path)
@@ -652,7 +651,7 @@ def strain_warren_function(L, h, k, l, lattice_parameter, average_lattice_parame
 def load_atomic_scattering_factor_coefficients():
     atomic_scattering_factor_coefficients = {}
 
-    path = os.path.join(resources.package_dirname("orangecontrib.wonder.controller.fit"), "data")
+    path = os.path.join(os.path.dirname(__file__), "data")
     file_name = os.path.join(path, "atomic_scattering_factor_coefficients.dat")
 
     file = open(file_name, "r")

--- a/orangecontrib/wonder/view/wonder/ow_diffraction_pattern.py
+++ b/orangecontrib/wonder/view/wonder/ow_diffraction_pattern.py
@@ -8,7 +8,6 @@ from silx.gui.plot.PlotWindow import PlotWindow
 
 from Orange.widgets.settings import Setting
 from Orange.widgets import gui as orangegui
-from Orange.canvas import resources
 
 from orangecontrib.wonder.util.widgets.ow_generic_widget import OWGenericWidget
 from orangecontrib.wonder.util.gui.gui_utility import gui, ConfirmDialog
@@ -30,7 +29,7 @@ class Wavelenght:
 wavelengths_data = {}
 
 def load_data_files():
-    directory_files = resources.package_dirname("orangecontrib.wonder.view.wonder") + "/data"
+    directory_files = os.path.join(os.path.dirname(__file__), "data")
 
     try:
         for path, dirs, files in os.walk(directory_files):


### PR DESCRIPTION
Since https://github.com/biolab/orange3/pull/3772 `Orange.canvas.resources` module is no longer present causing import error when wonder imports it.

Replace use of resources.package_dirname with appropriate `__file__` derived path.